### PR TITLE
Rework to instructions to ensure conda's access to git

### DIFF
--- a/00_SETUP.md
+++ b/00_SETUP.md
@@ -1,20 +1,7 @@
 # Configuring the Workshop Environment
-These directions walk through downloading the NAVO workshop material, installing miniconda, a lightweight distribution of the python package installer conda, then creating and testing the custom environment for the  workshop. 
+These directions walk through installing miniconda, a lightweight distribution of the python package installer conda, downloading the NAVO workshop material, then creating and testing the custom environment for the  workshop. 
 
-## 1. Clone This Repository
-
-Download the workshop folder using
-[git](https://help.github.com/articles/set-up-git/):
-
-    % git clone https://github.com/NASA-NAVO/aas_workshop_2020_winter.git
-
-If you don't have git installed, you can download the ZIP file by pressing the
-green *Clone or download* button at
-https://github.com/NASA-NAVO/aas_workshop_2020_winter and selecting *Download ZIP*.
-However, this option is not recommended because it impedes the ability to
-update your copy of the repository if updates are made.
-
-## 2. Install Miniconda (if needed)
+## 1. Install Miniconda (if needed)
 
 *Miniconda is a free minimal installer for conda. It is a small, bootstrap
 version of Anaconda that includes only conda, Python, the packages they depend
@@ -32,17 +19,15 @@ operating system: https://docs.conda.io/en/latest/miniconda.html
 On Windows, you might also need
 [additional compilers](https://github.com/conda/conda-build/wiki/Windows-Compilers).
 
-## 3. Create a conda environment for the workshop
+## 2. Open the conda command prompt
 
 *Miniconda includes an environment manager called conda. Environments
 allow you to have multiple sets of Python packages installed at the same
 time, making reproducibility and upgrades easier. You can create,
 export, list, remove, and update environments that have different versions of
-Python and/or packages installed in them. For this workshop, the python version 
-and all needed packages are listed in the
-[environment.yml](https://github.com/NASA-NAVO/aas_workshop_2020_winter/blob/master/environment.yml) file.*
+Python and/or packages installed in them. For this workshop, we will configure the environment using the conda command prompt.*
 
-On Mac or Linux, open your terminal and verify your shell environment:
+On Mac or Linux, the `bash` shell will handle the conda commands.  Open your terminal and verify your shell environment:
 
     % echo $SHELL
 
@@ -51,9 +36,31 @@ being able to run anything related to conda.
 
 On Windows, open the `Anaconda Prompt` terminal app.
 
-Now navigate to this directory in the terminal. For example, if you installed
+## 3. Install git (if needed)
+
+At the prompt opened in the previous step, enter this command to see whether git is already installed and accessible to this shell:
+
+    % git --version
+
+If the output shows a git version, proceed to the next step.  Otherwise install git by entering the following command and following the prompts:
+
+    % conda install git
+
+## 4. Clone This Repository
+
+Download the workshop folder using
+[git](https://help.github.com/articles/set-up-git/):
+
+    % git clone https://github.com/NASA-NAVO/aas_workshop_2020_winter.git
+
+## 3. Create a conda environment for the workshop
+
+*For this workshop, the python version and all needed packages are listed in the
+[environment.yml](https://github.com/NASA-NAVO/aas_workshop_2020_winter/blob/master/environment.yml) file.*
+
+Navigate to the workshop directory in the terminal. For example, if you installed
 the navo-workshop directory in your home directory, you could type the
-following.
+following:
 
     % cd aas_workshop_2020_winter
 

--- a/00_SETUP.md
+++ b/00_SETUP.md
@@ -53,7 +53,7 @@ Download the workshop folder using
 
     % git clone https://github.com/NASA-NAVO/aas_workshop_2020_winter.git
 
-## 3. Create a conda environment for the workshop
+## 5. Create a conda environment for the workshop
 
 *For this workshop, the python version and all needed packages are listed in the
 [environment.yml](https://github.com/NASA-NAVO/aas_workshop_2020_winter/blob/master/environment.yml) file.*
@@ -70,7 +70,7 @@ environment, type:
     % conda env create -n navo-workshop --file environment.yml
     % conda activate navo-workshop
 
-## 4. Check Installation
+## 6. Check Installation
 
 The name of the new conda environment created above should be displayed next
 to the terminal prompt:
@@ -82,7 +82,7 @@ required dependencies:
 
     (navo-workshop) % python check_env.py
 
-## 5. Starting Jupyterlab
+## 7. Starting Jupyterlab
 From the directory containing the notebooks:
 
     (navo-workshop) % jupyter lab


### PR DESCRIPTION
Testing on Windows showed that if the conda prompt (either an existing Anaconda or a new miniconda) did not have access to `git`, the environment elements installed from `git+git://github.com/...` silently failed to install.

The new instructions show how to check for `git` and `conda install` it if necessary.