### PR TITLE
Clean up catalog queries cheat sheet

### DIFF
--- a/CS_Catalog_queries.ipynb
+++ b/CS_Catalog_queries.ipynb
@@ -23,25 +23,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "import astropy.units as u\n",
-    "## There are a number of relatively unimportant warnings that \n",
-    "## show up, so for now, suppress them:\n",
+    "# suppress some specific warnings that are not important\n",
     "import warnings\n",
     "warnings.filterwarnings(\"ignore\", module=\"astropy.io.votable.*\")\n",
     "warnings.filterwarnings(\"ignore\", module=\"pyvo.utils.xml.*\")\n",
     "\n",
-    "## For simple astropy tables\n",
-    "import astropy, io\n",
+    "import io\n",
+    "import numpy as np\n",
     "\n",
-    "## For handling ordinary astropy Tables\n",
-    "from astropy.table import Table\n",
-    "\n",
-    "## For handling VO table type objects\n",
+    "# Astropy imports\n",
+    "import astropy.units as u\n",
+    "import astropy.constants as const\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy.cosmology import Planck15\n",
     "from astropy.io import votable as apvot\n",
     "\n",
     "## Generic VO access routines\n",
@@ -66,21 +64,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<SkyCoord (ICRS): (ra, dec) in deg\n",
-      "    (202.469575, 47.1952583)>\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import astropy.coordinates as coord\n",
-    "coord=coord.SkyCoord.from_name(\"m51\")\n",
+    "coord = SkyCoord.from_name(\"m51\")\n",
     "print(coord)"
    ]
   },
@@ -88,12 +76,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below, we go through the exercise of how we can figure out the most relevant table. But for now, let's assume that we know that we want the CFA redshift catalog refered to as 'zcat'. VO services are listed in a central Registry that can be searched through a [web interface](http://vao.stsci.edu/keyword-search/) or the python Registry class.  We use the registry to find the corresponding cone service and then submit our cone search. \n",
+    "Below, we go through the exercise of how we can figure out the most relevant table. But for now, let's assume that we know that we want the CFA redshift catalog refered to as 'zcat'. VO services are listed in a central Registry that can be searched through a [web interface](http://vao.stsci.edu/keyword-search/) or using PyVO's `regsearch`.  We use the registry to find the corresponding cone service and then submit our cone search. \n",
     "\n",
     "Registry services are of the following type:  \n",
     "* simple cone search:  \"scs\"\n",
-    "* table access protocol:  \"tap\"\n",
-    "* simple image search:  \"sia\"\n",
+    "* table access protocol:  \"tap\" or \"table\"\n",
+    "* simple image search:  \"sia\" or \"image\"\n",
     "* simple spectral access: \"ssa\"\n",
     "\n",
     "There are a number of things in the registry related to 'zcat' so we find the specific one that we want, which is the CFA version:"
@@ -101,53 +89,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<i>Table length=10</i>\n",
-       "<table id=\"table4853584336\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>ivoid</th><th>short_name</th><th>res_title</th></tr></thead>\n",
-       "<thead><tr><th>object</th><th>object</th><th>object</th></tr></thead>\n",
-       "<tr><td>ivo://cds.vizier/j/apj/872/134</td><td>J/ApJ/872/134</td><td>A uniformly selected, all-sky, optical AGN catalog (Zaw+, 2019)</td></tr>\n",
-       "<tr><td>ivo://cds.vizier/j/apj/872/134</td><td>J/ApJ/872/134</td><td>A uniformly selected, all-sky, optical AGN catalog (Zaw+, 2019)</td></tr>\n",
-       "<tr><td>ivo://cds.vizier/j/apj/872/134</td><td>J/ApJ/872/134</td><td>A uniformly selected, all-sky, optical AGN catalog (Zaw+, 2019)</td></tr>\n",
-       "<tr><td>ivo://cds.vizier/j/mnras/339/652</td><td>J/MNRAS/339/652</td><td>The FLASH Redshift Survey (Kaldare+ 2003)</td></tr>\n",
-       "<tr><td>ivo://cds.vizier/vii/259</td><td>VII/259</td><td>6dF galaxy survey final redshift release (Jones+, 2009)</td></tr>\n",
-       "<tr><td>ivo://cds.vizier/vii/259</td><td>VII/259</td><td>6dF galaxy survey final redshift release (Jones+, 2009)</td></tr>\n",
-       "<tr><td>ivo://nasa.heasarc/sixdfgs</td><td>SIXDFGS</td><td>6dFGS Galaxy Survey Final Redshift Release Catalog</td></tr>\n",
-       "<tr><td>ivo://nasa.heasarc/uzc</td><td>UZC</td><td>Updated Zwicky Catalog</td></tr>\n",
-       "<tr><td>ivo://nasa.heasarc/zcat</td><td>CFAZ</td><td>CfA Redshift Catalog (June 1995 Version)</td></tr>\n",
-       "<tr><td>ivo://wfau.roe.ac.uk/twompz-dsa</td><td></td><td>2MASS Photometric Redshift catalogue (2MPZ)</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Table length=10>\n",
-       "             ivoid               ...\n",
-       "             object              ...\n",
-       "-------------------------------- ...\n",
-       "  ivo://cds.vizier/j/apj/872/134 ...\n",
-       "  ivo://cds.vizier/j/apj/872/134 ...\n",
-       "  ivo://cds.vizier/j/apj/872/134 ...\n",
-       "ivo://cds.vizier/j/mnras/339/652 ...\n",
-       "        ivo://cds.vizier/vii/259 ...\n",
-       "        ivo://cds.vizier/vii/259 ...\n",
-       "      ivo://nasa.heasarc/sixdfgs ...\n",
-       "          ivo://nasa.heasarc/uzc ...\n",
-       "         ivo://nasa.heasarc/zcat ...\n",
-       " ivo://wfau.roe.ac.uk/twompz-dsa ..."
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "services=vo.regsearch(servicetype='scs',keywords=['zcat'])\n",
-    "services.to_table()['ivoid','short_name','res_title']"
+    "services = vo.regsearch(servicetype='scs', keywords=['zcat'])\n",
+    "services.to_table()['ivoid', 'short_name', 'res_title']"
    ]
   },
   {
@@ -161,42 +108,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<i>Table length=2</i>\n",
-       "<table id=\"table4853931256\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>name</th><th>ra</th><th>dec</th><th>bmag</th><th>radial_velocity</th><th>radial_velocity_error</th><th>redshift</th><th>class</th><th>Search_Offset</th></tr></thead>\n",
-       "<thead><tr><th></th><th>deg</th><th>deg</th><th></th><th>km / s</th><th>km / s</th><th></th><th></th><th></th></tr></thead>\n",
-       "<thead><tr><th>object</th><th>float64</th><th>float64</th><th>float32</th><th>int32</th><th>int16</th><th>float64</th><th>int16</th><th>float64</th></tr></thead>\n",
-       "<tr><td>N5194</td><td>202.46823</td><td>47.19815</td><td>9.03</td><td>474</td><td>23</td><td>--</td><td>6200</td><td>0.1819</td></tr>\n",
-       "<tr><td>N5195</td><td>202.49491</td><td>47.26792</td><td>10.94</td><td>558</td><td>23</td><td>--</td><td>6200</td><td>4.4802</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Table length=2>\n",
-       " name      ra      dec      bmag  ... redshift class Search_Offset\n",
-       "          deg      deg            ...                             \n",
-       "object  float64  float64  float32 ... float64  int16    float64   \n",
-       "------ --------- -------- ------- ... -------- ----- -------------\n",
-       " N5194 202.46823 47.19815    9.03 ...       --  6200        0.1819\n",
-       " N5195 202.49491 47.26792   10.94 ...       --  6200        4.4802"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "## Use the one that's CFAZ. \n",
-    "cfaz_cone_service=services[int(np.where(np.isin(services.to_table()['short_name'],b'CFAZ'))[0][0])]\n",
+    "cfaz_cone_service = services[int(np.where(np.isin(services.to_table()['short_name'], b'CFAZ'))[0][0])]\n",
     "\n",
     "## We are searching for sources within 10 arcminutes of M51. \n",
-    "results=cfaz_cone_service.search(pos=coord,radius=10./60.)\n",
+    "results = cfaz_cone_service.search(pos=coord, radius=10*u.arcmin)\n",
     "results.to_table()\n"
    ]
   },
@@ -236,28 +156,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Table length=1>\n",
-       "              ivoid               cap_index ...        harvested_from      \n",
-       "                                            ...                            \n",
-       "              object                int16   ...            object          \n",
-       "--------------------------------- --------- ... ---------------------------\n",
-       "ivo://nasa.heasarc/services/xamin         1 ... ivo://nasa.heasarc/registry"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "heasarc_tap_services=vo.regsearch(servicetype='tap',keywords=['heasarc'])\n",
-    "heasarc_tap_services"
+    "heasarc_tap_services = vo.regsearch(servicetype='tap', keywords=['heasarc'])\n",
+    "heasarc_tap_services.to_table()['ivoid', 'short_name', 'res_title']"
    ]
   },
   {
@@ -269,33 +173,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "abellzcat\n",
-      "    Abell Clusters Measured Redshifts Catalog\n",
-      "\n",
-      "Columns=['\"__row\"', '\"__x_ra_dec\"', '\"__y_ra_dec\"', '\"__z_ra_dec\"', 'abell_distance_class', 'abell_radius', 'abell_richness_class', 'bautz_morgan_class', 'bautz_morgan_flag', 'bii', 'class', 'dec', 'lii', 'log_redshift_ratio', 'mag_10', 'name', 'ra', 'redshift', 'redshift_flag', 'ref_redshift']\n",
-      "----\n",
-      "romabzcat\n",
-      "    Roma-BZCAT Multi-Frequency Catalog of Blazars\n",
-      "\n",
-      "Columns=['\"__row\"', '\"__x_ra_dec\"', '\"__y_ra_dec\"', '\"__z_ra_dec\"', 'bii', 'dec', 'flux_143_ghz', 'flux_1p4_ghz', 'gr_photon_flux', 'lii', 'name', 'object_type', 'ra', 'redshift', 'redshift_flag', 'rmag', 'ro_spectral_index', 'source_number', 'xray_flux']\n",
-      "----\n",
-      "zcat\n",
-      "    CfA Redshift Catalog (June 1995 Version)\n",
-      "\n",
-      "Columns=['\"__row\"', '\"__x_ra_dec\"', '\"__y_ra_dec\"', '\"__z_ra_dec\"', '\"distance\"', 'bar_type', 'bii', 'bmag', 'bt_mag', 'class', 'comments', 'dec', 'diameter_1', 'diameter_2', 'lii', 'luminosity_class', 'morph_type', 'name', 'notes', 'ra', 'radial_velocity', 'radial_velocity_error', 'redshift', 'ref_bmag', 'ref_radial_velocity', 'ref_redshift', 'rfn_number', 'structure', 'ugc_or_eso']\n",
-      "----\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "heasarc_tables=heasarc_tap_services[0].service.tables\n",
+    "heasarc_tables = heasarc_tap_services[0].service.tables\n",
     "for tablename in heasarc_tables.keys():\n",
     "    if \"zcat\" in tablename:  \n",
     "        heasarc_tables[tablename].describe()\n",
@@ -367,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +259,7 @@
     "##  are within radius 1deg of the given RA and DEC we got above for M51 \n",
     "##  (coord.ra.deg and coord.dec.deg from our variables defined above), and where \n",
     "##  the bmag column is less than 14.  \n",
-    "query=\"\"\"SELECT ra, dec, Radial_Velocity, radial_velocity_error, bmag, morph_type FROM public.zcat as cat where \n",
+    "query = \"\"\"SELECT ra, dec, Radial_Velocity, radial_velocity_error, bmag, morph_type FROM public.zcat as cat where \n",
     "    contains(point('ICRS',cat.ra,cat.dec),circle('ICRS',{},{},1.0))=1 and\n",
     "    cat.bmag < 14\n",
     "    order by cat.radial_velocity_error \n",
@@ -386,47 +268,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: AstropyDeprecationWarning: Using the table property is deprecated. Please use se to_table() instead. [pyvo.dal.query]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<i>Table length=3</i>\n",
-       "<table id=\"table4854077256\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>ra</th><th>dec</th><th>radial_velocity</th><th>radial_velocity_error</th><th>bmag</th><th>morph_type</th></tr></thead>\n",
-       "<thead><tr><th>float64</th><th>float64</th><th>int32</th><th>int16</th><th>float32</th><th>int16</th></tr></thead>\n",
-       "<tr><td>202.46823227</td><td>47.19814872</td><td>474</td><td>23</td><td>9.03</td><td>4</td></tr>\n",
-       "<tr><td>202.49490508</td><td>47.2679204</td><td>558</td><td>23</td><td>10.94</td><td>0</td></tr>\n",
-       "<tr><td>202.54744757</td><td>46.66995898</td><td>2569</td><td>25</td><td>13.3</td><td>-5</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Table length=3>\n",
-       "     ra          dec     radial_velocity ...   bmag  morph_type\n",
-       "  float64      float64        int32      ... float32   int16   \n",
-       "------------ ----------- --------------- ... ------- ----------\n",
-       "202.46823227 47.19814872             474 ...    9.03          4\n",
-       "202.49490508  47.2679204             558 ...   10.94          0\n",
-       "202.54744757 46.66995898            2569 ...    13.3         -5"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "#results=heasarc_tap_services[0].service.run_async(query)\n",
+    "# results = heasarc_tap_services[0].service.run_async(query)\n",
     "results=heasarc_tap_services[0].search(query) \n",
-    "results.table"
+    "results.to_table()"
    ]
   },
   {
@@ -445,11 +293,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "query=\"\"\"SELECT ra, dec, Radial_Velocity, radial_velocity_error, bmag, morph_type FROM public.zcat as cat where \n",
+    "query = \"\"\"SELECT ra, dec, Radial_Velocity, radial_velocity_error, bmag, morph_type FROM public.zcat as cat where \n",
     "    cat.bmag < 14 and cat.morph_type between 1 and 9 and cat.Radial_Velocity < 3000 \n",
     "    order by cat.Radial_velocity \n",
     "    \"\"\".format(coord.ra.deg, coord.dec.deg)"
@@ -457,83 +305,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: AstropyDeprecationWarning: Using the table property is deprecated. Please use se to_table() instead. [pyvo.dal.query]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<i>Table length=1120</i>\n",
-       "<table id=\"table4857507400\" class=\"table-striped table-bordered table-condensed\">\n",
-       "<thead><tr><th>ra</th><th>dec</th><th>radial_velocity</th><th>radial_velocity_error</th><th>bmag</th><th>morph_type</th></tr></thead>\n",
-       "<thead><tr><th>float64</th><th>float64</th><th>int32</th><th>int16</th><th>float32</th><th>int16</th></tr></thead>\n",
-       "<tr><td>10.6847407</td><td>41.26882595</td><td>-297</td><td>1</td><td>4.3</td><td>3</td></tr>\n",
-       "<tr><td>189.20757439</td><td>13.16274802</td><td>-223</td><td>18</td><td>10.58</td><td>2</td></tr>\n",
-       "<tr><td>186.73679277</td><td>15.04781754</td><td>-182</td><td>12</td><td>12.23</td><td>1</td></tr>\n",
-       "<tr><td>23.46217921</td><td>30.6601917</td><td>-180</td><td>1</td><td>6.5</td><td>5</td></tr>\n",
-       "<tr><td>186.49550755</td><td>15.67102319</td><td>-155</td><td>26</td><td>13.7</td><td>7</td></tr>\n",
-       "<tr><td>183.45114982</td><td>14.90009805</td><td>-98</td><td>15</td><td>11.0</td><td>2</td></tr>\n",
-       "<tr><td>183.91295676</td><td>13.90133935</td><td>-84</td><td>27</td><td>12.08</td><td>4</td></tr>\n",
-       "<tr><td>148.89928698</td><td>69.06297291</td><td>-40</td><td>5</td><td>7.75</td><td>2</td></tr>\n",
-       "<tr><td>68.21187756</td><td>71.88871924</td><td>-28</td><td>10</td><td>12.1</td><td>7</td></tr>\n",
-       "<tr><td>184.18072097</td><td>69.46565852</td><td>-7</td><td>4</td><td>10.4</td><td>8</td></tr>\n",
-       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
-       "<tr><td>25.54104856</td><td>12.60243687</td><td>2964</td><td>27</td><td>13.6</td><td>3</td></tr>\n",
-       "<tr><td>160.76076224</td><td>-36.36215965</td><td>2965</td><td>36</td><td>13.8</td><td>5</td></tr>\n",
-       "<tr><td>186.92023525</td><td>-8.27656738</td><td>2978</td><td>20</td><td>13.13</td><td>2</td></tr>\n",
-       "<tr><td>327.32061503</td><td>-60.6095822</td><td>2981</td><td>2</td><td>13.23</td><td>5</td></tr>\n",
-       "<tr><td>85.81306116</td><td>-30.07849161</td><td>2982</td><td>32</td><td>13.67</td><td>1</td></tr>\n",
-       "<tr><td>199.74246364</td><td>-47.9127092</td><td>2982</td><td>10</td><td>13.1</td><td>3</td></tr>\n",
-       "<tr><td>268.99556371</td><td>18.34046888</td><td>2986</td><td>20</td><td>13.4</td><td>2</td></tr>\n",
-       "<tr><td>234.99207988</td><td>58.08229864</td><td>2987</td><td>22</td><td>13.3</td><td>3</td></tr>\n",
-       "<tr><td>165.35109482</td><td>57.67702323</td><td>2994</td><td>20</td><td>13.7</td><td>5</td></tr>\n",
-       "<tr><td>149.05804536</td><td>59.30739142</td><td>2996</td><td>20</td><td>13.3</td><td>3</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Table length=1120>\n",
-       "     ra          dec      radial_velocity ...   bmag  morph_type\n",
-       "  float64      float64         int32      ... float32   int16   \n",
-       "------------ ------------ --------------- ... ------- ----------\n",
-       "  10.6847407  41.26882595            -297 ...     4.3          3\n",
-       "189.20757439  13.16274802            -223 ...   10.58          2\n",
-       "186.73679277  15.04781754            -182 ...   12.23          1\n",
-       " 23.46217921   30.6601917            -180 ...     6.5          5\n",
-       "186.49550755  15.67102319            -155 ...    13.7          7\n",
-       "183.45114982  14.90009805             -98 ...    11.0          2\n",
-       "183.91295676  13.90133935             -84 ...   12.08          4\n",
-       "148.89928698  69.06297291             -40 ...    7.75          2\n",
-       " 68.21187756  71.88871924             -28 ...    12.1          7\n",
-       "184.18072097  69.46565852              -7 ...    10.4          8\n",
-       "         ...          ...             ... ...     ...        ...\n",
-       " 25.54104856  12.60243687            2964 ...    13.6          3\n",
-       "160.76076224 -36.36215965            2965 ...    13.8          5\n",
-       "186.92023525  -8.27656738            2978 ...   13.13          2\n",
-       "327.32061503  -60.6095822            2981 ...   13.23          5\n",
-       " 85.81306116 -30.07849161            2982 ...   13.67          1\n",
-       "199.74246364  -47.9127092            2982 ...    13.1          3\n",
-       "268.99556371  18.34046888            2986 ...    13.4          2\n",
-       "234.99207988  58.08229864            2987 ...    13.3          3\n",
-       "165.35109482  57.67702323            2994 ...    13.7          5\n",
-       "149.05804536  59.30739142            2996 ...    13.3          3"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "#results=heasarc_tap_services[0].service.run_async(query)\n",
-    "results=heasarc_tap_services[0].search(query)\n",
-    "results.table"
+    "# results = heasarc_tap_services[0].service.run_async(query)\n",
+    "results = heasarc_tap_services[0].search(query)\n",
+    "results.to_table()"
    ]
   },
   {
@@ -542,12 +320,13 @@
    "source": [
     "## Synchronous versus asynchronous queries\n",
     "\n",
-    "There is one technical detail about TAP queries that you will need to know.  In the code cells above, there are two commands for sending the query, one of which is commented out.  This is because, with the TAP, there are two ways to send such queries.  The default when you use the search() method is to us a synchronous query, which means that the query is sent and the client waits for the response.  For large and complicated queries, this may time out, so there is another option.  The method service.run_async() uses an asynchronous query, which means that the query is sent, and then (under the hood without you needing to do anything), the method checks for a response.  From your point of view, these methods look the same;  PyVO is doing different things under the hood, but the method will not return until it has your result.  \n",
+    "There is one technical detail about TAP queries that you will need to know.  In the code cells above, there are two commands for sending the query, one of which is commented out.  This is because, with the TAP, there are two ways to send such queries.  The default when you use the `search()` method is to us a synchronous query, which means that the query is sent and the client waits for the response.  For large and complicated queries, this may time out, so there is another option.  The method `service.run_async()` uses an asynchronous query, which means that the query is sent, and then (under the hood without you needing to do anything), the method checks for a response.  From your point of view, these methods look the same;  PyVO is doing different things under the hood, but the method will not return until it has your result.  \n",
     "\n",
     "You need to know about these two methods for a couple of reasons.  First, some services will limit synchronous queries, i.e. they will not necessarily return *all* the results if there are too many of them.  An asynchronous query should have no such restrictions.  In the case of the HEASARC service that we use above, it does not matter, but you should be aware of this and be in the habit of using the asynchronous queries for complete results after an initial interactive exploration.  \n",
     "\n",
-    "The second reason to be aware of this is that asynchronous queries may be queued by the service, and they can take a lot longer if the service is very busy or the job is very large.  (The synchronous option in this case may either time out, or it may return quickly but with incomplete results.)  \n",
-    "\n"
+    "The second reason to be aware of this is that asynchronous queries may be queued by the service, and they can take a lot longer if the service is very busy or the job is very large.  (The synchronous option in this case may either time out, or it may return quickly but with incomplete results.)\n",
+    "\n",
+    "For very large queries, you may wish to use the `submit_job()`, `wait()`, and `fetch_results()` methods to avoid locking up your Python session, as described in the [pyvo documentation](https://pyvo.readthedocs.io/en/latest/dal/index.html#jobs).\n"
    ]
   },
   {
@@ -564,7 +343,7 @@
    "source": [
     "TAP can also be a powerful way to collect a lot of useful information from existing catalogs in one quick step. For this exercise, we will start with a list of sources, uploaded from our own table, and do a 'cross-correlation' with the *zcat* table. \n",
     "\n",
-    "For more on creating and working with VO tables, see that [notebook](VO_Tables.ipynb).  Here, we just read one in that's already prepared:  \n"
+    "For more on creating and working with VO tables, see that [notebook](CS_VO_Tables.ipynb).  Here, we just read one in that's already prepared:  \n"
    ]
   },
   {
@@ -576,32 +355,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "DALFormatError",
-     "evalue": "ValueError: 1:0: unclosed token",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m~/anaconda3/envs/navo-workshop/lib/python3.6/site-packages/pyvo/dal/query.py\u001b[0m in \u001b[0;36mexecute_votable\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    236\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 237\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mvotableparse\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexecute_stream\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    238\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mException\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/navo-workshop/lib/python3.6/site-packages/astropy/utils/decorators.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    520\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 521\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mfunction\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    522\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/navo-workshop/lib/python3.6/site-packages/astropy/io/votable/table.py\u001b[0m in \u001b[0;36mparse\u001b[0;34m(source, columns, invalid, verify, chunk_size, table_number, table_id, filename, unit_format, datatype_mapping, _debug_python_based_parser)\u001b[0m\n\u001b[1;32m    166\u001b[0m         return tree.VOTableFile(\n\u001b[0;32m--> 167\u001b[0;31m             config=config, pos=(1, 1)).parse(iterator, config)\n\u001b[0m\u001b[1;32m    168\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/navo-workshop/lib/python3.6/site-packages/astropy/io/votable/tree.py\u001b[0m in \u001b[0;36mparse\u001b[0;34m(self, iterator, config)\u001b[0m\n\u001b[1;32m   3504\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3505\u001b[0;31m         \u001b[0;32mfor\u001b[0m \u001b[0mstart\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtag\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpos\u001b[0m \u001b[0;32min\u001b[0m \u001b[0miterator\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3506\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mstart\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mValueError\u001b[0m: 1:0: unclosed token",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mDALFormatError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-11-a908322ceaea>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      7\u001b[0m     ORDER by cat.ra\"\"\"\n\u001b[1;32m      8\u001b[0m \u001b[0;31m#zcattable=heasarc_tap_services[0].service.run_async(query,uploads={'mysources':\"data/my_sources.xml\"})\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 9\u001b[0;31m \u001b[0mzcattable\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mheasarc_tap_services\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msearch\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mquery\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0muploads\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m{\u001b[0m\u001b[0;34m'mysources'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\"data/my_sources.xml\"\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     10\u001b[0m \u001b[0mzcattable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtable\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/navo-workshop/lib/python3.6/site-packages/pyvo/registry/regtap.py\u001b[0m in \u001b[0;36msearch\u001b[0;34m(self, *args, **keys)\u001b[0m\n\u001b[1;32m    361\u001b[0m                     self.short_name))\n\u001b[1;32m    362\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 363\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mservice\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msearch\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkeys\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    364\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    365\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mdescribe\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mverbose\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwidth\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m78\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfile\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/navo-workshop/lib/python3.6/site-packages/pyvo/dal/tap.py\u001b[0m in \u001b[0;36mrun_sync\u001b[0;34m(self, query, language, maxrec, uploads, **keywords)\u001b[0m\n\u001b[1;32m    216\u001b[0m         return self.create_query(\n\u001b[1;32m    217\u001b[0m             \u001b[0mquery\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlanguage\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mlanguage\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmaxrec\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmaxrec\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0muploads\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0muploads\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 218\u001b[0;31m             **keywords).execute()\n\u001b[0m\u001b[1;32m    219\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    220\u001b[0m     \u001b[0;31m# alias for service discovery\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/navo-workshop/lib/python3.6/site-packages/pyvo/dal/tap.py\u001b[0m in \u001b[0;36mexecute\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    910\u001b[0m            \u001b[0;32mfor\u001b[0m \u001b[0merrors\u001b[0m \u001b[0mparsing\u001b[0m \u001b[0mthe\u001b[0m \u001b[0mVOTable\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    911\u001b[0m         \"\"\"\n\u001b[0;32m--> 912\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mTAPResults\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexecute_votable\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0murl\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mqueryurl\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msession\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_session\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    913\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    914\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0msubmit\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/anaconda3/envs/navo-workshop/lib/python3.6/site-packages/pyvo/dal/query.py\u001b[0m in \u001b[0;36mexecute_votable\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    238\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mException\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    239\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraise_if_error\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 240\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mDALFormatError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0me\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mqueryurl\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    241\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    242\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mraise_if_error\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mDALFormatError\u001b[0m: ValueError: 1:0: unclosed token"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "query=\"\"\"\n",
     "    SELECT cat.ra, cat.dec, Radial_Velocity, bmag, morph_type\n",
@@ -610,9 +366,10 @@
     "    contains(point('ICRS',cat.ra,cat.dec),circle('ICRS',mt.ra,mt.dec,0.01))=1\n",
     "    and Radial_Velocity > 0\n",
     "    ORDER by cat.ra\"\"\"\n",
-    "#zcattable=heasarc_tap_services[0].service.run_async(query,uploads={'mysources':\"data/my_sources.xml\"})\n",
-    "zcattable=heasarc_tap_services[0].search(query,uploads={'mysources':\"data/my_sources.xml\"})\n",
-    "zcattable.table"
+    "# zcattable = heasarc_tap_services[0].service.run_async(query, uploads={'mysources': 'data/my_sources.xml'})\n",
+    "zcattable = heasarc_tap_services[0].search(query, uploads={'mysources': 'data/my_sources.xml'})\n",
+    "mytable = zcattable.to_table()\n",
+    "mytable"
    ]
   },
   {
@@ -643,23 +400,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mytable = zcattable.table\n",
-    "## The radial_velocity is in km/s, and this is just c*z, so\n",
-    "c=3.0e5 # km/s\n",
-    "redshifts=mytable['radial_velocity'].filled(0.)/c  # Filling masked values with zero\n",
-    "mytable['redshift']=redshifts\n",
-    "from astropy import units\n",
-    "physdist=0.05*units.Mpc # 50 kpc physical distance\n",
+    "## The column 'radial_velocity' is c*z but doesn't include the unit; it is km/s\n",
+    "## Get the speed of light from astropy.constants and express in km/s\n",
+    "c = const.c.to(u.km/u.s).value \n",
+    "redshifts = mytable['radial_velocity']/c \n",
+    "mytable['redshift'] = redshifts\n",
+    "physdist = 0.05*u.Mpc # 50 kpc physical distance\n",
     "\n",
-    "## This needs scipy.  \n",
-    "from astropy.cosmology import Planck15\n",
-    "angDdist=Planck15.angular_diameter_distance(mytable['redshift'])\n",
-    "## angDdist is returned from the astropy.cosmology module as a Quantity object, \n",
-    "##  i.e. a value and a unit.  Arctan is smart enough not to operate on quantities\n",
-    "##  that aren't unitless.  So angDdist.value to just get the value.\n",
-    "angDrad=np.arctan(physdist/angDdist)\n",
-    "angDdeg=angDrad*units.deg/units.rad\n",
-    "mytable['angDdeg']=angDdeg\n",
+    "angDdist = Planck15.angular_diameter_distance(mytable['redshift'])\n",
+    "angDrad = np.arctan(physdist/angDdist)\n",
+    "mytable['angDdeg'] = angDrad.to(u.deg)\n",
     "mytable"
    ]
   },
@@ -678,10 +428,9 @@
    "source": [
     "## In memory only, use an IO stream. \n",
     "vot_obj=io.BytesIO()\n",
-    "print(mytable.columns)\n",
     "apvot.writeto(apvot.from_table(mytable),vot_obj)\n",
     "## (Reset the \"file-like\" object to the beginning.)\n",
-    "vot_obj.seek(0)\n"
+    "vot_obj.seek(0)"
    ]
   },
   {
@@ -706,9 +455,10 @@
     "    and cat.Radial_Velocity > 0 and cat.radial_velocity != mt.radial_velocity\n",
     "    ORDER by cat.ra\"\"\"\n",
     "\n",
-    "#mytable2=heasarc_tap_services[0].service.run_async(query,uploads={'mytable':vot_obj})\n",
-    "mytable2=heasarc_tap_services[0].search(query,uploads={'mytable':vot_obj})\n",
-    "mytable2"
+    "# mytable2 = heasarc_tap_services[0].service.run_async(query, uploads={'mytable':vot_obj})\n",
+    "mytable2 = heasarc_tap_services[0].search(query, uploads={'mytable':vot_obj})\n",
+    "vot_obj.close()\n",
+    "mytable2.to_table()"
    ]
   },
   {


### PR DESCRIPTION
Fixes #2 

* Change `.table` to `.to_table()
* Move all imports to the first cell and remove unused ones
* Fix some of the Markdown cells
* Add explanation that very large queries might want to use `submit_job` etc.

Note that 6b025784a0975485f61c4e2174be595212af08ef fixed the missing data file but inadvertently  committed an executed version of the notebook, so the diff is large for this PR.